### PR TITLE
Add CLI override for the duration of a job

### DIFF
--- a/iot_testbed_client.py
+++ b/iot_testbed_client.py
@@ -945,6 +945,10 @@ if __name__ == '__main__':
     startGroup.add_argument('--now', action='store_true',
                             help="overwrite start_time fields with 'now'")
 
+    scheduleParser.add_argument('--duration', type=int,
+                                default=None,
+                                help="overwrite the duration of the job (in seconds)")
+
     scheduleParser.add_argument('jobFile',
                                 help='the json file that decribe the job',
                                 nargs='+')
@@ -1149,6 +1153,9 @@ if __name__ == '__main__':
 
                 if args.now:
                     job.start_time = 'now'
+
+                if args.duration is not None:
+                    job.duration = args.duration
 
                 if len(errs) == 0:
                     print("Submit job to testbed")


### PR DESCRIPTION
This pull request enables users to override the duration specified in the job file directly from the CLI.
So `iot_testbed_client.py schedule test.json --duration 600` should now schedule a job of 10min (600s) regardless of the specified in the job file.
If no duration is specified in the CLI the duration specified in the job file is used instead.