### PR TITLE
Add check for matching expected and received length of downloaded job

### DIFF
--- a/iot_testbed_client.py
+++ b/iot_testbed_client.py
@@ -635,6 +635,16 @@ class IoTTestbed:
         if not filename:
             filename = f"job_{jobId}.tar.gz"
 
+        cLen = r.headers.get('content-length')
+        if cLen is None:
+            raise Exception('Received data does not contain expected content-length')
+
+        cLen = int(cLen)
+
+        if cLen != len(r.content):
+            raise Exception("Received data is of different length than expected "
+                            f"(received: {len(r.content)} expected: {cLen})")
+
         fpath = destDir.joinpath(filename)
         count = fpath.write_bytes(r.content)
 
@@ -1178,8 +1188,9 @@ if __name__ == '__main__':
                     fname, nBytes = tiot.download(id, args.dest_dir,
                                                   args.no_delete, args.unzip)
                     print(f"Saved {nBytes} bytes in {fname}")
-                except Exception:
-                    pass
+                except Exception as ex:
+                    print(f'Could not download the {id} job')
+                    print(ex)
 
         elif args.command == 'reservation':
             try:


### PR DESCRIPTION
Due to slow connections or big archives, the download of the job can sometimes take a long time leading to it being abruptly stopped by the server. Still, the server's response has a 200 HTTP response status code.
As such the client continues its execution which, unless otherwise specified (e.g. with --no-delete), means sending the server a request to delete the job from its memory. This leaves the user with a corrupted archive and a deleted job archive on the server side.  

The change proposed mitigates this by checking that the expected size of the download, found in the content-length header, matches the size of the received file. If they do not match an exception is raised preventing the deletion of the job archive.
Moreover, some code was added to print information about exceptions blocking the download process to make the issue easier to detect.